### PR TITLE
Corrects config syntax.

### DIFF
--- a/pages/docs/theming.mdx
+++ b/pages/docs/theming.mdx
@@ -11,17 +11,19 @@ You can create additional themes that override your default [tokens](/docs/token
 
 ```jsx
 const { styled, css } = createStyled({
-  colors: {
-    $hiContrast: 'hsl(206,10%,5%)',
-    $loContrast: 'white',
+  tokens: {
+    colors: {
+      $hiContrast: 'hsl(206,10%,5%)',
+      $loContrast: 'white',
 
-    $gray100: 'hsl(206,22%,99%)',
-    $gray200: 'hsl(206,12%,97%)',
-    $gray300: 'hsl(206,11%,92%)',
-    $gray400: 'hsl(206,10%,84%)',
-    $gray500: 'hsl(206,10%,76%)',
-    $gray600: 'hsl(206,10%,44%)',
-  },
+      $gray100: 'hsl(206,22%,99%)',
+      $gray200: 'hsl(206,12%,97%)',
+      $gray300: 'hsl(206,11%,92%)',
+      $gray400: 'hsl(206,10%,84%)',
+      $gray500: 'hsl(206,10%,76%)',
+      $gray600: 'hsl(206,10%,44%)',
+    },
+  }
 });
 ```
 


### PR DESCRIPTION
The example here shows `colors` as a root config property, but it should be a property of the `tokens` object instead.