### PR TITLE
Add more details to compound variant example

### DIFF
--- a/pages/docs/variants.mdx
+++ b/pages/docs/variants.mdx
@@ -111,7 +111,23 @@ render(
 
 In the case of needing to set styles of a variant, based on a combination of other variants, you can use the `compoundVariant` function.
 
-The `compoundVariant` function takes two arguments, the first one is an object that defines that combination of variants used as a condition for the compound variant, the second is the style object that should be applied when the condition is met.
+```js
+Button.compoundVariant(
+  {
+    color: 'violet',
+    appearance: 'outline',
+  },
+  {
+    color: 'blueViolet',
+    borderColor: 'darkviolet',
+    ':hover': {
+      color: 'white',
+    },
+  }
+);
+```
+
+The `compoundVariant` function takes two arguments, the first one is an object that defines that combination of variants used as a condition, the second is the style object that should be applied when the condition is met.
 
 ```jsx live manual
 const Button = styled('button', {

--- a/pages/docs/variants.mdx
+++ b/pages/docs/variants.mdx
@@ -127,7 +127,7 @@ Button.compoundVariant(
 );
 ```
 
-The `compoundVariant` function takes two arguments, the first one is an object that defines that combination of variants used as a condition, the second is the style object that should be applied when the condition is met.
+The `compoundVariant` function takes two arguments, the first one is an object that defines a combination of variants to be used as the condition for the compound variant, the second is the style object that should be applied when that condition is met.
 
 ```jsx live manual
 const Button = styled('button', {

--- a/pages/docs/variants.mdx
+++ b/pages/docs/variants.mdx
@@ -109,7 +109,9 @@ render(
 
 #### Compound variants
 
-In the case of needing to set styles of a variant, based on another variant, you can use the `compoundVariant` function:
+In the case of needing to set styles of a variant, based on a combination of other variants, you can use the `compoundVariant` function.
+
+The `compoundVariant` function takes two arguments, the first one is an object that defines that combination of variants used as a condition for the compound variant, the second is the style object that should be applied when the condition is met.
 
 ```jsx live manual
 const Button = styled('button', {


### PR DESCRIPTION
I found it a bit confusing at first and took me a while to understand that the first argument of the compound variant was the condition for the variant that referred the other variants.

This adds a bit more context to that section