### PR TITLE
Update the documentation to mention "stitches-site" and "design-system" as references

### DIFF
--- a/pages/docs/frequently-asked-questions.mdx
+++ b/pages/docs/frequently-asked-questions.mdx
@@ -12,3 +12,9 @@ CSS rules are at zero risk of specificity wars. Since every rule gets its own cl
 There are no prop interpolations. Changes to styles are defined as `variants` and composed in the consumption layer. This means there are no style re-evaluations at runtime.
 
 The only work Stitches does in terms of evaluation is the first time a unique rule occurs. It creates an atomic class. If it occurs again, the cached class is reused.
+
+#### Where can I see Stitches used in production?
+
+You're looking at it!
+
+This website is built using Stitches, more precisely, using [components](https://github.com/modulz/design-system/tree/master/components) from a design system built using Stitches. If you're curious, check this out: https://github.com/modulz/design-system/

--- a/pages/docs/tutorials.mdx
+++ b/pages/docs/tutorials.mdx
@@ -1,6 +1,16 @@
 ---
 title: Tutorials
-description: Screencasts to help you get up and running with Stitches.
+description: Resources to help you get up and running with Stitches.
 ---
+
+### Demo
+
+This website is built using Stitches, making use of all the features offered by the library. You can look at the code behind it to see how it's been created.
+
+If you [look at the code on GitHub](https://github.com/modulz/stitches-site), you will see that behind the scenes it's using components coming from the [Modulz design system](https://github.com/modulz/design-system).
+
+All the components in the system are built using Stitches, and they support [tokens](/docs/tokens), [variants](/docs/variants), and a [dark theme](/docs/theming). Explore [their code implementation](https://github.com/modulz/design-system/tree/master/components), to find inspiration, ideas and design patterns on how to use Stitches in a real-world application.
+
+### Screencasts
 
 Coming soon!


### PR DESCRIPTION
I have updated the website to mention the website and the Modulz design system repositories as possible source of knowledge. Feel free to edit the text I have added, this is just a proposal.