### PR TITLE
HeroCodeDemo: replace flex gap

### DIFF
--- a/components/HeroCodeDemo.tsx
+++ b/components/HeroCodeDemo.tsx
@@ -94,7 +94,8 @@ const demoCode = `const Button = styled('button', {
   textDecoration: 'none',
   appearance: 'none',
   transition: 'all 200ms ease',
-
+  margin: '0px 16px',
+  
   ':hover': {
     boxShadow: '0 5px 15px rgba(0, 0, 0, .12)',
     transform: 'translateY(-2px)',
@@ -115,7 +116,7 @@ const demoCode = `const Button = styled('button', {
 });
 
 render(
-  <div style={{ display: 'flex', justifyContent: 'center', gap: '35px' }}>
+  <div style={{ display: 'flex', justifyContent: 'center' }}>
     <Button as="a" href="/docs/installation">Documentation</Button>
     <Button color="white" as="a" href="https://github.com/modulz/stitches">GitHub</Button>
   </div>


### PR DESCRIPTION
Flex gap is not supported yet on a lot of browsers (most notably Safari which is common on macOS and powers the rendering for all other browsers on iOS). I was recommended stitches by a friend so went to check it out and found the spacing of the buttons quite jarring and unprofessional ![screenshot](https://media.discordapp.net/attachments/718148876372279379/763106460397076480/unknown.png).
A polyfill could be used to solve this but I just chose to replace it with a margin instead as it's a lot easier.