### PR TITLE
Fix extractedStyles type on nextjs _document (post + app)

### DIFF
--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -8,7 +8,7 @@ export default class Document extends NextDocument {
     const originalRenderPage = ctx.renderPage;
 
     try {
-      let extractedStyles;
+      let extractedStyles: string[] | undefined;
       ctx.renderPage = () => {
         const { styles, result } = css.getStyles(originalRenderPage);
         extractedStyles = styles;
@@ -23,7 +23,7 @@ export default class Document extends NextDocument {
           <>
             {initialProps.styles}
 
-            {extractedStyles.map((content, index) => (
+            {extractedStyles?.map((content, index) => (
               <style key={index} dangerouslySetInnerHTML={{ __html: content }} />
             ))}
           </>

--- a/pages/blog/using-nextjs-with-stitches/index.mdx
+++ b/pages/blog/using-nextjs-with-stitches/index.mdx
@@ -77,7 +77,7 @@ export default class Document extends NextDocument {
     const originalRenderPage = ctx.renderPage;
 
     try {
-      let extractedStyles;
+      let extractedStyles: string[] | undefined;
       ctx.renderPage = () => {
         const { styles, result } = css.getStyles(originalRenderPage);
         extractedStyles = styles;
@@ -92,7 +92,7 @@ export default class Document extends NextDocument {
           <>
             {initialProps.styles}
 
-            {extractedStyles.map((content, index) => (
+            {extractedStyles?.map((content, index) => (
               <style key={index} dangerouslySetInnerHTML={{ __html: content }} />
             ))}
           </>


### PR DESCRIPTION
just to be sure 😅 my editor was complaining about it..

wonder if there’s a cleaner way of doing it without `let`..