### PR TITLE
fix: add label to color scheme toggle button

### DIFF
--- a/components/ThemeToggle.tsx
+++ b/components/ThemeToggle.tsx
@@ -10,6 +10,7 @@ export const ThemeToggle = (props) => {
       variant="ghost"
       onClick={() => (theme === 'dark' ? setTheme('light') : setTheme('dark'))}
       {...props}
+      aria-label="toggle a light and dark color scheme"
     >
       <svg
         xmlns="http://www.w3.org/2000/svg"


### PR DESCRIPTION
This PR adds a label to the color scheme toggle button, so that it can be perceived by assistive technology.