### PR TITLE
fix: reduce webfont shift

### DIFF
--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -37,6 +37,7 @@ export function Hero() {
       <Container size="3">
         <Title
           css={{
+            letterSpacing: '-.055--title',
             mb: '$3',
             '@bp1': {
               pr: 100,
@@ -55,6 +56,7 @@ export function Hero() {
         <Subtitle
           as="p"
           css={{
+            letterSpacing: '-.016--subtitle',
             mb: '$6',
             '@bp2': {
               mx: 230,

--- a/components/MDXComponents.tsx
+++ b/components/MDXComponents.tsx
@@ -102,7 +102,7 @@ export const components = {
           fontSize: '19px',
           lineHeight: '23px',
           fontWeight: 500,
-          letterSpacing: '-.031--letter-spacing-ratio',
+          letterSpacing: '-.031--h4',
           scrollMarginTop: '$6',
         }}
         as={'h4' as any}

--- a/components/MDXComponents.tsx
+++ b/components/MDXComponents.tsx
@@ -102,6 +102,7 @@ export const components = {
           fontSize: '19px',
           lineHeight: '23px',
           fontWeight: 500,
+          letterSpacing: '-.031--letter-spacing-ratio',
           scrollMarginTop: '$6',
         }}
         as={'h4' as any}
@@ -167,7 +168,7 @@ export const components = {
     <DS.Text
       size="4"
       {...props}
-      css={{ mb: '$3', lineHeight: '27px', letterSpacing: 0, ...props.css }}
+      css={{ mb: '$3', lineHeight: '27px', letterSpacing: '$$letter-spacing', ...props.css }}
       as="p"
     />
   ),

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -19,6 +19,7 @@ const globalStyles = global({
 
   'body, button': {
     fontFamily: '$untitled',
+    letterSpacing: '0.015em'
   },
 
   svg: { display: 'block' },

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -8,6 +8,22 @@ import { DocsPage } from '@components/DocsPage';
 import { useAnalytics } from '@lib/analytics';
 
 const globalStyles = global({
+  ':root': {
+    '--letter-spacing': '0',
+    '--h4': '1em',
+    '--heading': '1em',
+    '--title': '1em',
+    '--subtitle': '1em',
+
+    '&.no-untitled_sans': {
+      '--letter-spacing': '0.015em',
+      '--h4': '0.25em',
+      '--heading': '-0.5em',
+      '--title': '-.05em',
+      '--subtitle': '-1.5em'
+    }
+  },
+
   html: {
     overflowX: 'hidden',
   },
@@ -31,8 +47,14 @@ const globalStyles = global({
   },
 });
 
+if (typeof document === 'object') {
+  const a = () => document.fonts.check('1em "Untitled Sans"') ? document.documentElement.classList.remove('no-untitled_sans') : requestAnimationFrame(a)
+  a()
+}
+
 function App({ Component, pageProps }: AppProps) {
   globalStyles();
+
   const router = useRouter();
 
   useAnalytics();

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -10,6 +10,20 @@ export default class Document extends NextDocument {
         <Head>
           <style id="stitches" dangerouslySetInnerHTML={{ __html: getCssString() }} />
           <script dangerouslySetInnerHTML={{ __html: renderSnippet() }} />
+          <style dangerouslySetInnerHTML={{
+            __html: (
+              `:root{---letter-spacing:0;--letter-spacing-ratio:1em;--heading:1em;--title:1em;--subtitle:1em}`
+              + `:root.js-no-untitled_sans{---letter-spacing:0.015em;--letter-spacing-ratio:0.25em;--heading:-0.5em;--title:-.05em;--subtitle:-1.5em}`
+            )
+          }} />
+          <script dangerouslySetInnerHTML={{
+            __html: (
+              `document.documentElement.classList.add('js-no-untitled_sans');`
+              + `((a=()=>document.fonts.check('1em "Untitled Sans"')?document.documentElement.classList.remove('js-no-untitled_sans'):requestAnimationFrame(a))=>`
+              + `a()`
+              + `)()`
+            )
+          }} />
           <link rel="icon" href="/favicon.png" />
           <link rel="stylesheet" href="https://develop.modulz.app/fonts/fonts.css" />
         </Head>

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -6,24 +6,10 @@ import { renderSnippet } from '@lib/analytics';
 export default class Document extends NextDocument {
   render() {
     return (
-      <Html lang="en">
+      <Html lang="en" className="no-untitled_sans">
         <Head>
           <style id="stitches" dangerouslySetInnerHTML={{ __html: getCssString() }} />
           <script dangerouslySetInnerHTML={{ __html: renderSnippet() }} />
-          <style dangerouslySetInnerHTML={{
-            __html: (
-              `:root{---letter-spacing:0;--letter-spacing-ratio:1em;--heading:1em;--title:1em;--subtitle:1em}`
-              + `:root.js-no-untitled_sans{---letter-spacing:0.015em;--letter-spacing-ratio:0.25em;--heading:-0.5em;--title:-.05em;--subtitle:-1.5em}`
-            )
-          }} />
-          <script dangerouslySetInnerHTML={{
-            __html: (
-              `document.documentElement.classList.add('js-no-untitled_sans');`
-              + `((a=()=>document.fonts.check('1em "Untitled Sans"')?document.documentElement.classList.remove('js-no-untitled_sans'):requestAnimationFrame(a))=>`
-              + `a()`
-              + `)()`
-            )
-          }} />
           <link rel="icon" href="/favicon.png" />
           <link rel="stylesheet" href="https://develop.modulz.app/fonts/fonts.css" />
         </Head>

--- a/pages/docs/[slug].tsx
+++ b/pages/docs/[slug].tsx
@@ -26,11 +26,11 @@ export default function Doc({ frontmatter, source }: Doc) {
     <>
       <TitleAndMetaTags title={`${frontmatter.title} — Stitches`} />
 
-      <Text as="h1" size="8" css={{ fontWeight: 500, mb: '$2', lineHeight: '40px' }}>
+      <Text as="h1" size="8" css={{ fontWeight: 500, mb: '$2', lineHeight: '40px', letterSpacing: '-.034--heading' }}>
         {frontmatter.title}
       </Text>
 
-      <Text as="h2" size="6" css={{ mt: '$2', mb: '$4', color: '$slate900', lineHeight: '30px' }}>
+      <Text as="h2" size="6" css={{ mt: '$2', mb: '$4', color: '$slate900', lineHeight: '30px', letterSpacing: '-.016--heading' }}>
         {frontmatter.description}
       </Text>
 
@@ -138,7 +138,7 @@ function QuickNav({ content }) {
           display: headings.length === 0 ? 'none' : 'block',
         }}
       >
-        <Subheading css={{ mb: '$3' }} id="site-quick-nav-heading">
+        <Subheading css={{ mb: '$3', letterSpacing: '-.015--heading' }} id="site-quick-nav-heading">
           Quick nav
         </Subheading>
         <QuickNavUl>


### PR DESCRIPTION
This PR reduces the text and layout shift between when the page has visibly loaded and when the **Untitled Sans** webfont has visibly loaded.