### PR TITLE
Update api.mdx

### DIFF
--- a/data/docs/api.mdx
+++ b/data/docs/api.mdx
@@ -206,8 +206,8 @@ createCss({
 
 Define how the `style` tag is inserted. Available values are:
 
-- `append` (default) - `style` tag will be inserted as the first child of the `head` element.
-- `prepend` - `style` tag will be inserted as the last child of the `head` element. This is useful if you're including third party CSS and want Stitches to have a higher specificity.
+- `prepend` (default) - `style` tag will be inserted as the first child of the `head` element.
+- `append` - `style` tag will be inserted as the last child of the `head` element. This is useful if you're including third party CSS and want Stitches to have a higher specificity.
 - `function` - custom function, you're in control.
 
 ```jsx line=2-18


### PR DESCRIPTION
The documentation is wrong about the `insertionMethod` behavior: `prepend` is the default one. Also see https://github.com/modulz/stitches/pull/550 - once merged it will be possible to actually overwrite the `prepend` with `append` 😃