### PR TITLE
Update <head> tag ordering

### DIFF
--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -8,10 +8,9 @@ export default class Document extends NextDocument {
     return (
       <Html lang="en">
         <Head>
+          <link rel="stylesheet" href="https://develop.modulz.app/fonts/fonts.css" />
           <style id="stitches" dangerouslySetInnerHTML={{ __html: getCssString() }} />
           <script dangerouslySetInnerHTML={{ __html: renderSnippet() }} />
-          <link rel="icon" href="/favicon.png" />
-          <link rel="stylesheet" href="https://develop.modulz.app/fonts/fonts.css" />
         </Head>
         <body>
           <Main />


### PR DESCRIPTION
This moves the fonts declaration to the top of the `<head>`, similar to how it is ordered on the Radix UI website.