### PR TITLE
Add cursor:pointer for cards

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -339,7 +339,7 @@ export default function Home() {
                   as="button"
                   onMouseDown={() => setVariantsCodeActiveHighlight('one')}
                   variant={variantsCodeActiveHighlight === 'one' ? 'active' : 'ghost'}
-                  css={{ p: '$3', mb: '$2', width: '100%' }}
+                  css={{ p: '$3', mb: '$2', width: '100%', cursor: 'pointer' }}
                 >
                   <Text css={{ fontWeight: 500, lineHeight: '22px', mb: '$1' }}>Variants</Text>
                   <Text variant="gray" css={{ lineHeight: '22px' }}>
@@ -350,7 +350,7 @@ export default function Home() {
                   as="button"
                   onMouseDown={() => setVariantsCodeActiveHighlight('two')}
                   variant={variantsCodeActiveHighlight === 'two' ? 'active' : 'ghost'}
-                  css={{ p: '$3', mb: '$2', width: '100%' }}
+                  css={{ p: '$3', mb: '$2', width: '100%', cursor: 'pointer' }}
                 >
                   <Text css={{ fontWeight: 500, lineHeight: '22px', mb: '$1' }}>
                     Compound Variants
@@ -363,7 +363,7 @@ export default function Home() {
                   as="button"
                   onMouseDown={() => setVariantsCodeActiveHighlight('three')}
                   variant={variantsCodeActiveHighlight === 'three' ? 'active' : 'ghost'}
-                  css={{ p: '$3', mb: '$2', width: '100%' }}
+                  css={{ p: '$3', mb: '$2', width: '100%', cursor: 'pointer' }}
                 >
                   <Text css={{ fontWeight: 500, lineHeight: '22px', mb: '$1' }}>
                     Default Variants
@@ -422,7 +422,7 @@ export default function Home() {
                   as="button"
                   onMouseDown={() => setThemingCodeActiveHighlight('one')}
                   variant={themingCodeActiveHighlight === 'one' ? 'active' : 'ghost'}
-                  css={{ p: '$3', mb: '$2', width: '100%' }}
+                  css={{ p: '$3', mb: '$2', width: '100%', cursor: 'pointer' }}
                 >
                   <Text css={{ fontWeight: 500, lineHeight: '22px', mb: '$1' }}>Tokens</Text>
                   <Text variant="gray" css={{ lineHeight: '22px' }}>
@@ -433,7 +433,7 @@ export default function Home() {
                   as="button"
                   onMouseDown={() => setThemingCodeActiveHighlight('two')}
                   variant={themingCodeActiveHighlight === 'two' ? 'active' : 'ghost'}
-                  css={{ p: '$3', mb: '$2', width: '100%' }}
+                  css={{ p: '$3', mb: '$2', width: '100%', cursor: 'pointer' }}
                 >
                   <Text css={{ fontWeight: 500, lineHeight: '22px', mb: '$1' }}>Token aliases</Text>
                   <Text variant="gray" css={{ lineHeight: '22px' }}>
@@ -444,7 +444,7 @@ export default function Home() {
                   as="button"
                   onMouseDown={() => setThemingCodeActiveHighlight('three')}
                   variant={themingCodeActiveHighlight === 'three' ? 'active' : 'ghost'}
-                  css={{ p: '$3', mb: '$2', width: '100%' }}
+                  css={{ p: '$3', mb: '$2', width: '100%', cursor: 'pointer' }}
                 >
                   <Text css={{ fontWeight: 500, lineHeight: '22px', mb: '$1' }}>Themes</Text>
                   <Text variant="gray" css={{ lineHeight: '22px' }}>
@@ -673,7 +673,7 @@ export default function Home() {
                   as="button"
                   onMouseDown={() => setTokensCodeActiveHighlight('one')}
                   variant={tokensActiveHighlight === 'one' ? 'active' : 'ghost'}
-                  css={{ p: '$3', mb: '$2', width: '100%' }}
+                  css={{ p: '$3', mb: '$2', width: '100%', cursor: 'pointer' }}
                 >
                   <Text css={{ fontWeight: 500, lineHeight: '22px', mb: '$1' }}>
                     Smart token mapping
@@ -686,7 +686,7 @@ export default function Home() {
                   as="button"
                   onMouseDown={() => setTokensCodeActiveHighlight('two')}
                   variant={tokensActiveHighlight === 'two' ? 'active' : 'ghost'}
-                  css={{ p: '$3', mb: '$2', width: '100%' }}
+                  css={{ p: '$3', mb: '$2', width: '100%', cursor: 'pointer' }}
                 >
                   <Text css={{ fontWeight: 500, lineHeight: '22px', mb: '$1' }}>
                     Specific token mapping
@@ -745,7 +745,7 @@ export default function Home() {
                   as="button"
                   onMouseDown={() => setUtilsCodeActiveHighlight('one')}
                   variant={utilsCodeActiveHighlight === 'one' ? 'active' : 'ghost'}
-                  css={{ p: '$3', mb: '$2', width: '100%' }}
+                  css={{ p: '$3', mb: '$2', width: '100%', cursor: 'pointer' }}
                 >
                   <Text css={{ fontWeight: 500, lineHeight: '22px', mb: '$1' }}>
                     Property shorthands
@@ -758,7 +758,7 @@ export default function Home() {
                   as="button"
                   onMouseDown={() => setUtilsCodeActiveHighlight('two')}
                   variant={utilsCodeActiveHighlight === 'two' ? 'active' : 'ghost'}
-                  css={{ p: '$3', mb: '$2', width: '100%' }}
+                  css={{ p: '$3', mb: '$2', width: '100%', cursor: 'pointer' }}
                 >
                   <Text css={{ fontWeight: 500, lineHeight: '22px', mb: '$1' }}>
                     Property bundles
@@ -771,7 +771,7 @@ export default function Home() {
                   as="button"
                   onMouseDown={() => setUtilsCodeActiveHighlight('three')}
                   variant={utilsCodeActiveHighlight === 'three' ? 'active' : 'ghost'}
-                  css={{ p: '$3', mb: '$2', width: '100%' }}
+                  css={{ p: '$3', mb: '$2', width: '100%', cursor: 'pointer' }}
                 >
                   <Text css={{ fontWeight: 500, lineHeight: '22px', mb: '$1' }}>
                     Simplify syntax


### PR DESCRIPTION
Previously, the cursor remained the default when hovering over the cards on the homepage, this changes them to a pointer to make it more clear to the user that they are clickable