### PR TITLE
docs: fix utils docs on value type assertion

### DIFF
--- a/data/docs/utils.mdx
+++ b/data/docs/utils.mdx
@@ -83,7 +83,7 @@ You can type the value against a specific scale to improve the developer experie
 ```jsx
 export const { styled, css } = createCss({
   utils: {
-    mx: (config) => (value: `$${keyof typeof config['theme']['space'] | (string & {})}`) => ({
+    mx: (config) => (value: `$${keyof typeof config['theme']['space']}` | (string & {})) => ({
       marginLeft: value,
       marginRight: value,
     }),


### PR DESCRIPTION
Before this fix, the value of the utils would be always string, not showing any intellisense when being used.

