### PR TITLE
Fixes broken link to default theme map in API docs.

### DIFF
--- a/data/docs/api.mdx
+++ b/data/docs/api.mdx
@@ -226,7 +226,7 @@ createCss({
 });
 ```
 
-Here's a list of the [default mapping](https://github.com/modulz/stitches/blob/canary/packages/core/src/defaultThemeMap.js#L11-L155).
+Here's a list of the [default mapping](https://github.com/modulz/stitches/blob/canary/packages/core/src/default/defaultThemeMap.js#L17).
 
 > Note: this overrides the default mapping. Import [defaultThemeMap](/docs/api#defaultthememap) to merge with default.
 


### PR DESCRIPTION
I didn't include the whole block, in case the line numbers change. Just included the line number for the starting point.