### PR TITLE
globalCss replaced with global

### DIFF
--- a/data/docs/styling.mdx
+++ b/data/docs/styling.mdx
@@ -12,7 +12,7 @@ In order to keep the bundle size to a minimum, Stitches uses JavaScript object n
 For handling things like global resets, you can write global CSS styles. The `global` function will return another function, which you must call in your app.
 
 ```jsx line=1-3,6
-const globalStyles = globalCss({
+const globalStyles = global({
   '*': { margin: 0, padding: 0 },
 });
 


### PR DESCRIPTION
I assume this is the correct change? globalCss didn't work for me.