### PR TITLE
CSS Property Correction : Change `backgroundColor` to `color`

### DIFF
--- a/data/docs/styling.mdx
+++ b/data/docs/styling.mdx
@@ -436,7 +436,7 @@ const Grid = styled('div', {
 
 Stitches is aware of your tokens by using a [property-to-token mapping](/docs/tokens#property-mapping). To apply a token you need to prefix it with a `$` sign.
 
-For example, the `backgroundColor` property automatically maps to the `colors` tokens.
+For example, the `color` property automatically maps to the `colors` tokens.
 
 ```jsx
 import { createStitches } from '@stitches/react';


### PR DESCRIPTION
This PR updates the example under  [Token aware values](https://stitches.dev/docs/styling#token-aware-values) to read "the `color` property" instead of `backgroundColor`. 