### PR TITLE
Correct mistaken access to `keyframes` via non-existing `css`

### DIFF
--- a/data/blog/migrating-from-emotion-to-stitches.mdx
+++ b/data/blog/migrating-from-emotion-to-stitches.mdx
@@ -267,7 +267,7 @@ const Box = styled.div`
 // Stitches
 import { keyframes } from '@stitches/react';
 
-const fadeIn = css.keyframes({
+const fadeIn = keyframes({
   '0%': { opacity: '0' },
   '100%': { opacity: '1' },
 });


### PR DESCRIPTION
Seems like this example might have had a different import in the past, considering the way keyframes is imported just above.