### PR TITLE
Remove reference to old utils syntax

### DIFF
--- a/data/docs/utils.mdx
+++ b/data/docs/utils.mdx
@@ -52,7 +52,7 @@ export const { styled, css } = createStitches({
 });
 ```
 
-> The `config` is your [configuration](/docs/installation#create-your-config-file) and the `value` will be the value passed in via the CSS property.
+> `value` will be the value passed in via the CSS property.
 
 {
 


### PR DESCRIPTION
This removes a reference to the old `utils` syntax that received the `config` object.