### PR TITLE
Replace const with type in variant extraction

### DIFF
--- a/data/docs/typescript.mdx
+++ b/data/docs/typescript.mdx
@@ -101,8 +101,8 @@ const StyledButton = styled('button', {
   }
 })
 
-const CSSButtonVariants = Stitches.VariantProps<typeof cssButton>
-const StyledButtonVariants = Stitches.VariantProps<typeof StyledButton>
+type CSSButtonVariants = Stitches.VariantProps<typeof cssButton>
+type StyledButtonVariants = Stitches.VariantProps<typeof StyledButton>
 ```
 
 ## Type utils as CSS Properties and tokens


### PR DESCRIPTION
This replaces the `const` with `type` in variant extraction