### PR TITLE
adds getCssText to stitches.config

### DIFF
--- a/data/blog/using-gatsby-with-stitches.mdx
+++ b/data/blog/using-gatsby-with-stitches.mdx
@@ -59,7 +59,7 @@ Finally, export the `styled` and `css` functions.
 ```jsx
 import { createStitches } from '@stitches/react';
 
-export const { styled, css } = createStitches({
+export const { styled, css, getCssText } = createStitches({
   tokens: {
     fonts: {
       system: 'system-ui',


### PR DESCRIPTION
Following this post I realized the `getCssText` isn't getting exported. This could cause confusion for a dev who isn't familiar with stitches. 