### PR TITLE
Add: Changed breakpoint example to use updated range syntax

### DIFF
--- a/data/docs/breakpoints.mdx
+++ b/data/docs/breakpoints.mdx
@@ -8,9 +8,9 @@ Define your media at-rules in the `media` object. You can add as many as you nee
 ```jsx line=2-6
 export const { styled, css } = createStitches({
   media: {
-    bp1: '(min-width: 640px)',
-    bp2: '(min-width: 768px)',
-    bp3: '(min-width: 1024px)',
+    bp1: '(640px <= width < 768px)',
+    bp2: '(768px <= width < 1024px)',
+    bp3: '(1024px <= width)',
   },
 });
 ```


### PR DESCRIPTION
**Changed**:
- Updated the breakpoint example to use new media query syntax [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/Media_Queries/Using_media_queries#syntax_improvements_in_level_4)

**Other options:**
- I suppose you could also use (not sure what's preferred):
  ```
  export const { styled, css } = createStitches({
    media: {
      bp1: '(width >= 640px)',
      bp2: '(width >= 768px)',
      bp3: '(width >= 1024px)',
    },
  });
  ```

I used https://github.com/modulz/stitches/issues/725#issuecomment-977188448 as a reference
