### PR TITLE
docs(framework-agnostic.mdx): remove getCssText from core import

### DIFF
--- a/data/docs/framework-agnostic.mdx
+++ b/data/docs/framework-agnostic.mdx
@@ -72,9 +72,8 @@ import {
   css,
   __globalCss__,
   __keyframes__,
-  __theme__,
   __createTheme__,
-  __getCssText__,
+  __createStitches__,
 } from '@stitches/core';
 ```
 


### PR DESCRIPTION
In docs it is mentioned that we can import `getCssText` from `@stitches/core` but seems like it is not working. The `getCssText` is returned from `createStitches` API.

I checked the exports in the code and there too it doesn't seem like we're exporting `getCssText` directly.

Let me know if I misunderstood something! Thanks for building this!